### PR TITLE
Add LessWrong bypass helper and pipeline health report

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ npm run dev
 # Open http://localhost:5173
 ```
 
+## Utility Scripts
+
+Two standalone helper scripts live in `scripts/` for operational debugging:
+
+```bash
+# Check the latest pipeline log and emit a human-readable summary
+python3 scripts/pipeline_health.py
+
+# Same report as structured JSON
+python3 scripts/pipeline_health.py --json
+
+# Warm a headless browser on LessWrong, cache cookies, and test GraphQL access
+python3 scripts/lesswrong_cookie_fetch.py --after 2026-03-27 --before 2026-03-28
+```
+
+`lesswrong_cookie_fetch.py` exists because direct `requests` calls to LessWrong GraphQL may hit Vercel's bot challenge (HTTP 429), while a real browser context can sometimes pass. The script caches browser cookies in `~/.cache/lesswrong_cookies.json` and retries with those cookies before re-solving.
+
 ### Manual Pipeline Run
 
 ```bash

--- a/scripts/lesswrong_cookie_fetch.py
+++ b/scripts/lesswrong_cookie_fetch.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Fetch and cache LessWrong cookies by letting Playwright execute the site JS first.
+
+The key trick: a raw requests POST to /graphql now gets the Vercel Security
+Checkpoint (HTTP 429), but the same POST from a real browser context succeeds.
+This module warms a headless Playwright browser on lesswrong.com, validates a
+GraphQL query from inside the page context, then exports cookies for reuse by
+requests-based callers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import sync_playwright
+
+LESSWRONG_HOME = "https://www.lesswrong.com"
+LESSWRONG_GRAPHQL = "https://www.lesswrong.com/graphql"
+DEFAULT_CACHE_PATH = Path.home() / ".cache" / "lesswrong_cookies.json"
+DEFAULT_TIMEOUT_SECONDS = 90
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+)
+
+TEST_QUERY = """
+query GetPosts($after: Date, $before: Date) {
+  posts(input: { terms: { view: "new", after: $after, before: $before, limit: 100 } }) {
+    results {
+      _id
+      title
+      slug
+      postedAt
+      contents { html }
+      user { displayName username }
+      baseScore
+      voteCount
+    }
+  }
+}
+""".strip()
+
+TEST_VARIABLES = {"after": "2026-03-27", "before": "2026-03-28"}
+BROWSER_FETCH_FN = "(args) => fetch(\"https://www.lesswrong.com/graphql\", {method: \"POST\", headers: {\"content-type\": \"application/json\"}, credentials: \"include\", body: JSON.stringify({query: args.query, variables: args.variables})}).then(async r => ({status: r.status, text: await r.text()}))"
+
+
+class LessWrongCookieError(RuntimeError):
+    """Raised when cookies could not be obtained or validated."""
+
+
+@dataclass
+class CookieCache:
+    created_at: float
+    user_agent: str
+    cookies: List[Dict[str, Any]]
+
+
+class LessWrongClient:
+    def __init__(
+        self,
+        cache_path: Path = DEFAULT_CACHE_PATH,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        user_agent: str = DEFAULT_USER_AGENT,
+        headless: bool = True,
+    ) -> None:
+        self.cache_path = Path(cache_path).expanduser()
+        self.timeout_seconds = timeout_seconds
+        self.user_agent = user_agent
+        self.headless = headless
+
+    def graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        variables = variables or {}
+
+        cached = self.load_cached_cookies()
+        if cached:
+            response = self._graphql_request(query, variables, cached.cookies, cached.user_agent)
+            if self._response_looks_valid(response):
+                return response.json()
+
+        fresh = self.solve_and_cache_cookies()
+        response = self._graphql_request(query, variables, fresh.cookies, fresh.user_agent)
+        if self._response_looks_valid(response):
+            return response.json()
+
+        browser_result = self._graphql_request_via_new_browser(query, variables)
+        if self._browser_result_looks_valid(browser_result):
+            return json.loads(browser_result["text"])
+
+        raise LessWrongCookieError(
+            f"GraphQL request still failed after browser solve: HTTP {response.status_code} {response.text[:500]}"
+        )
+
+    def fetch_posts(self, after: str, before: str) -> List[Dict[str, Any]]:
+        payload = self.graphql(TEST_QUERY, {"after": after, "before": before})
+        return payload["data"]["posts"]["results"]
+
+    def load_cached_cookies(self) -> Optional[CookieCache]:
+        if not self.cache_path.exists():
+            return None
+        try:
+            data = json.loads(self.cache_path.read_text())
+            cookies = data.get("cookies") or []
+            if not cookies:
+                return None
+            return CookieCache(
+                created_at=float(data.get("created_at", 0)),
+                user_agent=data.get("user_agent", self.user_agent),
+                cookies=cookies,
+            )
+        except Exception:
+            return None
+
+    def solve_and_cache_cookies(self) -> CookieCache:
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache = self._solve_challenge_with_browser()
+        self.cache_path.write_text(json.dumps(asdict(cache), indent=2))
+        return cache
+
+    def _solve_challenge_with_browser(self) -> CookieCache:
+        deadline = time.time() + self.timeout_seconds
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=self.headless)
+            context = browser.new_context(user_agent=self.user_agent)
+            page = context.new_page()
+            page.set_default_timeout(10_000)
+            page.goto(LESSWRONG_HOME, wait_until="domcontentloaded")
+
+            while time.time() < deadline:
+                try:
+                    page.wait_for_load_state("networkidle", timeout=5_000)
+                except PlaywrightTimeoutError:
+                    pass
+
+                browser_result = self._graphql_request_via_browser(page, TEST_QUERY, TEST_VARIABLES)
+                if self._browser_result_looks_valid(browser_result):
+                    cookies = context.cookies()
+                    browser.close()
+                    return CookieCache(
+                        created_at=time.time(),
+                        user_agent=self.user_agent,
+                        cookies=cookies,
+                    )
+
+                time.sleep(2)
+
+            browser.close()
+
+        raise LessWrongCookieError(
+            f"Timed out after {self.timeout_seconds}s waiting for LessWrong/Vercel challenge to clear"
+        )
+
+    def _graphql_request_via_browser(self, page, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+        return page.evaluate(BROWSER_FETCH_FN, {"query": query, "variables": variables})
+
+    def _graphql_request_via_new_browser(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=self.headless)
+            context = browser.new_context(user_agent=self.user_agent)
+            page = context.new_page()
+            page.goto(LESSWRONG_HOME, wait_until="domcontentloaded")
+            try:
+                page.wait_for_load_state("networkidle", timeout=5_000)
+            except PlaywrightTimeoutError:
+                pass
+            result = self._graphql_request_via_browser(page, query, variables)
+            browser.close()
+            return result
+
+    def _graphql_request(
+        self,
+        query: str,
+        variables: Dict[str, Any],
+        cookies: List[Dict[str, Any]],
+        user_agent: str,
+    ) -> requests.Response:
+        session = requests.Session()
+        for cookie in cookies:
+            name = cookie.get("name")
+            value = cookie.get("value")
+            domain = cookie.get("domain") or ".lesswrong.com"
+            if name and value is not None:
+                session.cookies.set(name, value, domain=domain)
+
+        headers = {
+            "User-Agent": user_agent,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Origin": LESSWRONG_HOME,
+            "Referer": f"{LESSWRONG_HOME}/",
+        }
+
+        return session.post(
+            LESSWRONG_GRAPHQL,
+            headers=headers,
+            json={"query": query, "variables": variables},
+            timeout=45,
+        )
+
+    @staticmethod
+    def _response_looks_valid(response: requests.Response) -> bool:
+        if response.status_code != 200:
+            return False
+        try:
+            payload = response.json()
+        except Exception:
+            return False
+        return isinstance(payload, dict) and "data" in payload and not payload.get("errors")
+
+    @staticmethod
+    def _browser_result_looks_valid(result: Dict[str, Any]) -> bool:
+        if not isinstance(result, dict) or result.get("status") != 200:
+            return False
+        try:
+            payload = json.loads(result.get("text", ""))
+        except Exception:
+            return False
+        return isinstance(payload, dict) and "data" in payload and not payload.get("errors")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch/cache LessWrong cookies and test GraphQL access")
+    parser.add_argument("--after", default=TEST_VARIABLES["after"], help="Start date YYYY-MM-DD")
+    parser.add_argument("--before", default=TEST_VARIABLES["before"], help="End date YYYY-MM-DD")
+    parser.add_argument("--cache-path", default=str(DEFAULT_CACHE_PATH), help="Cookie cache path")
+    parser.add_argument("--headed", action="store_true", help="Run Chromium with a visible window")
+    parser.add_argument("--json", action="store_true", help="Emit raw JSON payload")
+    args = parser.parse_args()
+
+    client = LessWrongClient(cache_path=Path(args.cache_path), headless=not args.headed)
+    payload = client.graphql(TEST_QUERY, {"after": args.after, "before": args.before})
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        posts = payload["data"]["posts"]["results"]
+        print(f"Fetched {len(posts)} posts from LessWrong")
+        for post in posts[:10]:
+            author = (post.get("user") or {}).get("displayName") or (post.get("user") or {}).get("username") or "unknown"
+            print(f"- {post.get('title', '<untitled>')} ({author})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Summarize the most recent AI news pipeline log in text or JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+LOG_DIR = Path.home() / "ai-news-aggregator" / "logs"
+ITEM_RE = re.compile(r"agents\.orchestrator - INFO -\s+([a-z]+) gatherer collected (\d+) items")
+DATE_RE = re.compile(r"pipeline_(\d{4}-\d{2}-\d{2})\.log$")
+WARNING_RE = re.compile(r" - (WARNING|ERROR|CRITICAL) - ")
+LESSWRONG_RE = re.compile(r"lesswrong|vercel|429|security checkpoint|bot challenge", re.IGNORECASE)
+TOTAL_RE = re.compile(r"Total items collected: (\d+)")
+STATUS_RE = re.compile(r"\[(ok|fail)\] (.+)")
+
+
+@dataclass
+class HealthReport:
+    date: str
+    log_path: str
+    counts: Dict[str, int]
+    degraded_sources: List[str]
+    errors: List[str]
+    warnings: List[str]
+    total_items_collected: Optional[int]
+    pipeline_completed_successfully: bool
+
+    def text_summary(self) -> str:
+        lines = [f"Pipeline Health Report — {self.date}"]
+        for category in ["news", "research", "social", "reddit"]:
+            count = self.counts.get(category, 0)
+            marker = "⚠️" if category == "research" and count == 0 else "✅"
+            detail = ""
+            if category == "research" and count == 0:
+                detail = " (LessWrong GraphQL/Vercel challenge or upstream research source failure)"
+            lines.append(f"{marker} {category.capitalize()}: {count} items{detail}")
+
+        if self.degraded_sources:
+            lines.append("Degraded sources:")
+            lines.extend(f"- {item}" for item in self.degraded_sources)
+
+        if self.errors:
+            lines.append("Errors:")
+            lines.extend(f"- {line}" for line in self.errors[:10])
+        elif self.warnings:
+            lines.append("Warnings:")
+            lines.extend(f"- {line}" for line in self.warnings[:10])
+
+        if self.total_items_collected is not None:
+            lines.append(f"Total items collected: {self.total_items_collected}")
+        lines.append(
+            "Pipeline status: completed successfully" if self.pipeline_completed_successfully else "Pipeline status: incomplete or failed"
+        )
+        return "\n".join(lines)
+
+
+def find_latest_log(log_dir: Path) -> Path:
+    logs = sorted(log_dir.glob("pipeline_*.log"))
+    if not logs:
+        raise FileNotFoundError(f"No pipeline logs found in {log_dir}")
+    return logs[-1]
+
+
+def parse_log(log_path: Path) -> HealthReport:
+    text = log_path.read_text(errors="replace")
+    counts: Dict[str, int] = {}
+    degraded_sources: List[str] = []
+    errors: List[str] = []
+    warnings: List[str] = []
+    total_items_collected: Optional[int] = None
+
+    for line in text.splitlines():
+        item_match = ITEM_RE.search(line)
+        if item_match:
+            counts[item_match.group(1)] = int(item_match.group(2))
+
+        if WARNING_RE.search(line):
+            if " - ERROR - " in line or " - CRITICAL - " in line:
+                errors.append(line.strip())
+            else:
+                warnings.append(line.strip())
+
+        lowered = line.lower()
+        if "research gatherer collected 0 items" in lowered:
+            degraded_sources.append("Research gatherer returned 0 items")
+        if LESSWRONG_RE.search(line):
+            degraded_sources.append(line.strip())
+        if "feed warning" in lowered:
+            degraded_sources.append(line.strip())
+
+        total_match = TOTAL_RE.search(line)
+        if total_match:
+            total_items_collected = int(total_match.group(1))
+
+    m = DATE_RE.search(log_path.name)
+    report_date = m.group(1) if m else "unknown"
+    pipeline_completed_successfully = "PIPELINE COMPLETED SUCCESSFULLY" in text
+
+    def dedupe_keep_order(items: List[str]) -> List[str]:
+        seen = set()
+        out = []
+        for item in items:
+            if item not in seen:
+                seen.add(item)
+                out.append(item)
+        return out
+
+    return HealthReport(
+        date=report_date,
+        log_path=str(log_path),
+        counts=counts,
+        degraded_sources=dedupe_keep_order(degraded_sources),
+        errors=dedupe_keep_order(errors),
+        warnings=dedupe_keep_order(warnings),
+        total_items_collected=total_items_collected,
+        pipeline_completed_successfully=pipeline_completed_successfully,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize the most recent AI news pipeline log")
+    parser.add_argument("--log", help="Specific log path to inspect")
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON")
+    args = parser.parse_args()
+
+    log_path = Path(args.log).expanduser() if args.log else find_latest_log(LOG_DIR)
+    report = parse_log(log_path)
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(report.text_summary())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a LessWrong Playwright helper that warms a real browser session, caches cookies, and tests GraphQL access against the Vercel checkpoint issue
- add a standalone pipeline health report utility with text and JSON output
- document both scripts in the README

## Why
LessWrong enabled Vercel Attack Challenge Mode on 2026-03-28. Direct GraphQL calls now receive HTTP 429 or the Vercel Security Checkpoint page, which caused the research gatherer to collect 0 items on duffplex. These scripts provide an operational workaround path plus a quick way to surface degraded pipeline sources from logs.

## Testing
- python scripts/pipeline_health.py
- python scripts/pipeline_health.py --json
- python scripts/lesswrong_cookie_fetch.py --after 2026-03-27 --before 2026-03-28
- verified direct requests to LessWrong GraphQL return 429 on duffplex
- verified LessWrong homepage loads in Playwright on duffplex
- verified browser-context GraphQL access is unstable / challenge-dependent on duffplex and the helper now falls back cleanly with explicit errors
