### PR TITLE
Use LessWrong cookie client for LessWrong GraphQL

### DIFF
--- a/agents/gatherers/research_gatherer.py
+++ b/agents/gatherers/research_gatherer.py
@@ -15,9 +15,11 @@ arXiv publishing schedule:
 import asyncio
 import logging
 import re
+import sys
 import time
 from datetime import datetime
 from email.utils import parsedate_to_datetime
+from pathlib import Path
 from typing import List, Optional
 
 import feedparser
@@ -25,6 +27,15 @@ import requests
 
 from ..base import BaseGatherer, CollectedItem
 from .arxiv_oai import ArxivOAIHarvester
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / 'scripts'
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+try:
+    from lesswrong_cookie_fetch import LessWrongClient
+except ImportError:
+    LessWrongClient = None
 
 logger = logging.getLogger(__name__)
 
@@ -445,15 +456,21 @@ class ResearchGatherer(BaseGatherer):
 
         try:
             logger.info(f"Fetching LessWrong posts via GraphQL (coverage: {self.coverage_date})")
-            response = requests.post(
-                'https://www.lesswrong.com/graphql',
-                json={'query': query, 'variables': variables},
-                headers={'Content-Type': 'application/json'},
-                timeout=30
-            )
-            response.raise_for_status()
+            data = None
 
-            data = response.json()
+            if LessWrongClient is not None:
+                logger.info("Using LessWrongClient cookie bypass for LessWrong GraphQL")
+                data = LessWrongClient().graphql(query, variables)
+            else:
+                logger.warning("LessWrongClient unavailable; falling back to direct GraphQL request")
+                response = requests.post(
+                    'https://www.lesswrong.com/graphql',
+                    json={'query': query, 'variables': variables},
+                    headers={'Content-Type': 'application/json'},
+                    timeout=30
+                )
+                response.raise_for_status()
+                data = response.json()
 
             if 'errors' in data:
                 logger.error(f"LessWrong GraphQL errors: {data['errors']}")


### PR DESCRIPTION
## Summary
- make the research gatherer import `LessWrongClient` from `scripts/lesswrong_cookie_fetch`
- use the Playwright-backed cookie bypass as the primary LessWrong GraphQL path
- keep the existing direct `requests.post()` call as a fallback only when the cookie client module is unavailable

## Why
LessWrong is now protected by Vercel Attack Challenge Mode, so the pipeline direct GraphQL POSTs commonly return HTTP 429 and fail to collect posts. The existing cookie solver already handles that challenge successfully, but the research gatherer was not using it.

## Testing
- activated `.venv` on duffplex
- imported `ResearchGatherer` and `LessWrongClient` successfully via a quick Python check
