### PR TITLE
fix(arxiv): stop Monday depending solely on OAI-PMH

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -610,7 +610,35 @@ jobs:
           # Exits 1 by design when it finds something; that is a finding, not a
           # job failure.
           python3 scripts/check_source_anomalies.py \
-            --web-dir ./web --date "$report_date" --alert || true
+            --web-dir ./web --date "$report_date" --alert 2>&1 | tee /tmp/anomaly_check.txt
+          check_rc="${PIPESTATUS[0]}"
+
+          # GitHub-native surfacing, added 2026-08-17. The webhook POST is the
+          # primary channel but it is best-effort and swallows its own errors: on
+          # 2026-08-17 the arXiv outage was detected correctly, the alert fired,
+          # and delivery returned HTTP 403 -- so the finding reached nobody. An
+          # annotation plus a job-summary entry cannot 403; they ride the run
+          # itself and reach whoever already watches the workflow.
+          if [ "$check_rc" = "1" ]; then
+            {
+              echo "### :rotating_light: Degraded sources on ${report_date}"
+              echo
+              echo '```'
+              cat /tmp/anomaly_check.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            while IFS= read -r line; do
+              echo "::error title=Degraded source::${line#  - }"
+            done < <(grep '^  - ' /tmp/anomaly_check.txt || true)
+          fi
+
+          # A failed alert delivery is itself a fault worth seeing: it means the
+          # next real outage is invisible on the primary channel too.
+          if grep -q 'Alert POST -> HTTP [45]' /tmp/anomaly_check.txt; then
+            echo "::error title=Alert delivery failed::check_source_anomalies could not deliver to the alert ingress (see log). The degradation channel is down; rotate PIPELINE_ALERT_TOKEN or check PIPELINE_ALERT_URL."
+            echo "> :warning: Alert POST to the ingress failed — the degradation channel is down." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # Replay presence check (2026-07-31). Phase 6.2 swallows its own failures by
       # design -- a broken replay must never cost us the report -- which makes it the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,8 @@ jobs:
         run: python3 -m unittest tests.replay_secret_guard_test -v
       - name: LessWrong browser proxy scheme is Chromium-legal (2026-08-05..08 outage)
         run: python3 -m unittest tests.lesswrong_proxy_scheme_test -v
+      - name: arXiv OAI retries, bounds, and admits partial harvests (2026-08-17 outage)
+        run: python3 -m unittest tests.arxiv_oai_resilience_test -v
 
   content-rendering:
     name: Content rendering guards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,10 @@ PIPELINE_PROXY_URL    # HTTP(S) or SOCKS proxy for the whole pipeline (optional)
 NEWS_USER_AGENT       # User-Agent sent to RSS/feed sources, incl. research blog feeds (optional)
 LINK_FOLLOWER_MAX_URLS # Max distinct URLs the link follower fetches per run; gate errors fail closed (default: 50)
 RESEARCH_FEED_TIMEOUT # Network timeout (seconds) for research blog feed fetches (default: 20)
+ARXIV_OAI_TIMEOUT     # Per-request read timeout for oaipmh.arxiv.org (default: 180)
+ARXIV_OAI_MAX_ATTEMPTS # Attempts per OAI-PMH request, including the first (default: 3)
+ARXIV_OAI_BACKOFF_SECONDS # Base for exponential backoff between OAI attempts (default: 5)
+ARXIV_OAI_DEADLINE_SECONDS # Wall-clock ceiling for a whole OAI harvest (default: 600)
 LLM_TRUST_ENV_PROXY   # Let LLM clients use HTTP(S)/ALL_PROXY env vars (default: false)
 LLM_TIMEOUT_SECONDS   # Override provider-config LLM request timeout (Actions default: 240)
 LLM_MAX_CONCURRENT_REQUESTS # Async LLM request cap per provider route; 0 disables it (default: 8)
@@ -510,7 +514,8 @@ the fact, and phase boundaries are reconstructed. Live runs measure all of it.
 
 ## Important Notes
 
-- **arXiv**: Uses arXiv RSS feeds for today's collection (no rate limits, more reliable) with automatic API fallback. For historical dates, uses API directly since RSS only contains current announcements. Only collects papers with `announce_type` of "new" or "cross" (skips replacements). arXiv only publishes papers on weekdays (Mon-Fri). Weekend dates will return 0 papers.
+- **arXiv**: Uses arXiv RSS feeds for today's collection (no rate limits, more reliable) with automatic OAI-PMH fallback, on **every** report weekday including Monday. For historical dates, uses OAI-PMH directly since RSS only contains current announcements. Only collects papers with `announce_type` of "new" or "cross" (skips replacements). arXiv only publishes papers on weekdays (Mon-Fri). Weekend *report* dates skip arXiv entirely.
+- **arXiv Monday catch-up**: Monday additionally sweeps Sat-Sun over OAI-PMH for stragglers, but only *after* RSS has supplied Monday's papers, and the sweep is best-effort — it can never discard what RSS returned. Measured 2026-08-17: a Sat→Mon OAI query returned 842 `cs` records, **all** datestamped Monday, so the weekend leg is normally empty by construction (arXiv makes no Fri/Sat-night announcements). Before 2026-08-17 Monday was OAI-*only*; when that endpoint stalled, the day published with zero arXiv papers and a green status. OAI-PMH is now retried (`ARXIV_OAI_MAX_ATTEMPTS`) with a bounded deadline, and an incomplete harvest marks the research source `partial` instead of `success`.
 - **LessWrong**: Uses GraphQL for date-range collection because RSS only exposes the newest posts. The helper tries direct GraphQL, cached cookies, and a Playwright browser warm-up. `LESSWRONG_PROXY_URL` can target only this source; otherwise `PIPELINE_PROXY_URL` is reused.
 - **Reddit (ScrapeCreators)**: The free Reddit `.json` endpoint and OAuth are dead, so Reddit collects via the ScrapeCreators API (`x-api-key`). Listings page `sort=new` newest→oldest and stop once the coverage window is passed (credit-cheap, complete; `REDDIT_MAX_PAGES` safety cap). The top `REDDIT_BODY_TOP_N` posts/sub are enriched via one `post/comments` call: self posts get their `selftext`; high-discussion link posts get a digest of top community comments (analyzer `content`). A hard `REDDIT_CREDIT_BUDGET` aborts calls gracefully if exceeded. Egress is direct (`trust_env=False`), bypassing the pipeline proxy/Mullvad. `sort=new` backfill of dates >2 days old is depth-limited and logs a warning.
 - **External API Usage**: Non-LLM paid APIs report per-run usage and live balance into the end-of-run cost summary (and `cost_report_{date}.json` under `external_apis`): ScrapeCreators shows calls/credits-consumed/remaining-balance, and TwitterAPI.io shows calls/tweets/`recharge_credits` balance ($1 = 100,000 credits). Balance probes are free.

--- a/agents/base.py
+++ b/agents/base.py
@@ -367,6 +367,17 @@ class BaseGatherer(ABC):
         # covers several independently-timed streams (research = arXiv + blogs).
         self.source_counts: Dict[str, int] = {}
 
+        # Reasons this gatherer's output is incomplete even though gather() returned
+        # normally. The orchestrator downgrades such a source from 'success' to
+        # 'partial' in collection_status.
+        #
+        # Existed because status was effectively binary: a gatherer reported success
+        # unless gather() raised, so a source that swallowed its own transport errors
+        # and returned a short list was indistinguishable from a genuinely quiet day.
+        # That is how the 2026-08-17 arXiv outage published as `research: success`
+        # with 12 items against a Monday median of 334.
+        self.degradation_reasons: List[str] = []
+
         # A window of <= 0 hours collects nothing, and would do so silently: every
         # source would report success with zero items. Refuse it rather than publish
         # an empty report.
@@ -417,6 +428,21 @@ class BaseGatherer(ABC):
             f"{self.__class__.__name__} initialized: report={self.report_date}, "
             f"coverage={self.coverage_date} ({self.start_time} to {self.end_time}){span_note}"
         )
+
+    def note_degradation(self, reason: str) -> None:
+        """Record that this gatherer's output is incomplete.
+
+        Idempotent per distinct reason, so a retry loop that reports the same
+        problem twice does not inflate the status message.
+        """
+        if reason and reason not in self.degradation_reasons:
+            self.degradation_reasons.append(reason)
+
+    def get_degradation(self) -> Optional[str]:
+        """One human-readable summary of why this source is short, or None."""
+        if not self.degradation_reasons:
+            return None
+        return "; ".join(self.degradation_reasons)
 
     @contextmanager
     def time_source(self, key: str):

--- a/agents/gatherers/arxiv_oai.py
+++ b/agents/gatherers/arxiv_oai.py
@@ -12,6 +12,8 @@ arXiv publishing schedule:
 - Monday's announcements cover all weekend submissions (Fri-Sun)
 """
 import logging
+import os
+import time
 from typing import List, Dict, Optional
 from xml.etree import ElementTree as ET
 
@@ -24,20 +26,93 @@ ARXIV_RAW_NS = "http://arxiv.org/OAI/arXivRaw/"
 OAI_NS = "http://www.openarchives.org/OAI/2.0/"
 
 
+def _env_float(name: str, default: float) -> float:
+    """Read a positive float from the environment, falling back on bad input."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(f"{name}={raw!r} is not a number; using {default}")
+        return default
+    if value <= 0:
+        logger.warning(f"{name}={value} must be positive; using {default}")
+        return default
+    return value
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(_env_float(name, float(default)))
+
+
+# Per-request read timeout. Measured 2026-08-17: a *successful* ListRecords for
+# the cs archive took 51.5s, and the previous 60s ceiling turned that into a
+# hard failure on a slow morning. The endpoint's latency is erratic rather than
+# uniformly slow -- the identical query returned in 0.6s, 51.5s, and >90s within
+# minutes of each other -- so the timeout is sized for the tail, not the median.
+DEFAULT_TIMEOUT = _env_float("ARXIV_OAI_TIMEOUT", 180.0)
+
+# Attempts per HTTP request, including the first. Retry buys more than a longer
+# timeout does against an endpoint that stalls intermittently.
+DEFAULT_MAX_ATTEMPTS = max(1, _env_int("ARXIV_OAI_MAX_ATTEMPTS", 3))
+
+# Base for exponential backoff between attempts (5s, 10s, 20s...).
+DEFAULT_BACKOFF = _env_float("ARXIV_OAI_BACKOFF_SECONDS", 5.0)
+
+# Whole-harvest wall-clock ceiling across every archive, page and retry. Without
+# it, timeout x attempts x pages x archives can run to tens of minutes and eat
+# the job's budget for a source that is already failing.
+DEFAULT_DEADLINE = _env_float("ARXIV_OAI_DEADLINE_SECONDS", 600.0)
+
+
 class ArxivOAIHarvester:
     """Harvest arXiv papers by announcement date using OAI-PMH."""
 
-    def __init__(self, categories: List[str]):
+    def __init__(
+        self,
+        categories: List[str],
+        timeout: Optional[float] = None,
+        max_attempts: Optional[int] = None,
+        backoff_seconds: Optional[float] = None,
+        deadline_seconds: Optional[float] = None,
+        sleep=time.sleep,
+        now=time.monotonic,
+    ):
         """
         Initialize harvester with list of arXiv categories.
 
         Args:
             categories: List of arXiv category codes (e.g., ['cs.AI', 'cs.LG', 'cs.CL'])
+            timeout: Per-request read timeout in seconds.
+            max_attempts: Attempts per request, including the first.
+            backoff_seconds: Base for exponential backoff between attempts.
+            deadline_seconds: Wall-clock ceiling for the whole harvest.
+            sleep: Injected for tests; must not be called in the happy path.
+            now: Monotonic clock, injected for tests.
         """
         self.categories = set(categories)
         # Group categories by archive for efficient querying
         # OAI-PMH only supports archive-level sets (e.g., 'cs', 'stat'), not subject classes
         self.archives = set(cat.split('.')[0] for cat in categories)
+
+        self.timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+        self.max_attempts = DEFAULT_MAX_ATTEMPTS if max_attempts is None else max(1, max_attempts)
+        self.backoff_seconds = DEFAULT_BACKOFF if backoff_seconds is None else backoff_seconds
+        self.deadline_seconds = DEFAULT_DEADLINE if deadline_seconds is None else deadline_seconds
+        self._sleep = sleep
+        self._now = now
+
+        # Archives whose harvest ended early -- transport failure, XML error, or
+        # the deadline. Non-empty means the returned paper list is a floor, not a
+        # complete answer, and the caller must not publish it as if it were whole.
+        # Reset at the start of every harvest_date call.
+        self.incomplete_archives: List[str] = []
+
+    @property
+    def last_harvest_complete(self) -> bool:
+        """False when the most recent harvest gave up on at least one archive."""
+        return not self.incomplete_archives
 
     def harvest_date(self, from_date: str, until_date: Optional[str] = None) -> List[Dict]:
         """
@@ -60,9 +135,12 @@ class ArxivOAIHarvester:
             logger.info(f"OAI-PMH harvesting papers for datestamp={from_date} to {query_until}, archives={self.archives}")
 
         papers = []
+        self.incomplete_archives = []
+        self._deadline_at = self._now() + self.deadline_seconds
 
-        # Query by archive (OAI-PMH only supports archive-level sets)
-        for archive in self.archives:
+        # Query by archive (OAI-PMH only supports archive-level sets). Sorted so
+        # a deadline cut-off truncates the same way run to run.
+        for archive in sorted(self.archives):
             try:
                 archive_papers = self._harvest_archive(from_date, query_until, archive)
                 # Filter to papers that match our target categories
@@ -75,6 +153,8 @@ class ArxivOAIHarvester:
                            f"(filtered from {len(archive_papers)} in archive)")
             except Exception as e:
                 logger.error(f"OAI-PMH error for archive {archive}: {e}")
+                if archive not in self.incomplete_archives:
+                    self.incomplete_archives.append(archive)
 
         # Deduplicate by arxiv_id (papers can appear in multiple categories)
         seen = set()
@@ -85,7 +165,18 @@ class ArxivOAIHarvester:
                 unique_papers.append(paper)
 
         date_desc = from_date if from_date == query_until else f"{from_date} to {query_until}"
-        logger.info(f"OAI-PMH total: {len(unique_papers)} unique new papers for {date_desc}")
+        if self.incomplete_archives:
+            # Loud, and distinct from a legitimately empty day: 0 papers because
+            # arXiv had none reads identically to 0 papers because the transport
+            # died, and that ambiguity is exactly how the 2026-08-17 outage
+            # published as a green run.
+            logger.error(
+                f"OAI-PMH INCOMPLETE for {date_desc}: gave up on "
+                f"{', '.join(self.incomplete_archives)}. "
+                f"{len(unique_papers)} papers is a floor, not the full set."
+            )
+        else:
+            logger.info(f"OAI-PMH total: {len(unique_papers)} unique new papers for {date_desc}")
         return unique_papers
 
     def _matches_categories(self, paper: Dict) -> bool:
@@ -93,8 +184,95 @@ class ArxivOAIHarvester:
         paper_categories = paper.get('categories', '').split()
         return any(cat in self.categories for cat in paper_categories)
 
+    # HTTP statuses worth another attempt. arXiv's OAI endpoint answers 503 with
+    # a Retry-After when it is shedding load, which is a request to wait, not a
+    # reason to give up.
+    RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+    def _budget_left(self) -> float:
+        """Seconds remaining before the whole-harvest deadline."""
+        return getattr(self, '_deadline_at', self._now() + self.deadline_seconds) - self._now()
+
+    def _retry_after_seconds(self, response) -> Optional[float]:
+        """Parse a Retry-After header, when the server sent a usable one."""
+        raw = (response.headers.get('Retry-After') or '').strip()
+        if not raw:
+            return None
+        try:
+            value = float(raw)
+        except ValueError:
+            return None  # HTTP-date form; fall back to our own backoff
+        return value if value >= 0 else None
+
+    def _request_with_retry(self, url: str, archive: str):
+        """GET a ListRecords page, retrying transient failures.
+
+        Raises the final exception when every attempt fails, so the caller can
+        record the archive as incomplete rather than mistake it for empty.
+        """
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, self.max_attempts + 1):
+            budget = self._budget_left()
+            if budget <= 0:
+                raise TimeoutError(
+                    f"OAI-PMH deadline of {self.deadline_seconds:.0f}s exhausted "
+                    f"before attempt {attempt} for {archive}"
+                )
+
+            # Never let one request outlive the whole-harvest budget.
+            timeout = min(self.timeout, budget)
+
+            try:
+                response = requests.get(url, timeout=timeout)
+            except requests.exceptions.RequestException as e:
+                # Transport-level failure (timeout, DNS, reset) -- always worth
+                # another go; this is the 2026-08-17 case.
+                last_error = e
+                if attempt < self.max_attempts:
+                    self._backoff(attempt, archive, e)
+                    continue
+                raise
+
+            if response.status_code in self.RETRYABLE_STATUS:
+                wait = self._retry_after_seconds(response)
+                last_error = requests.exceptions.HTTPError(
+                    f"HTTP {response.status_code} from OAI-PMH"
+                )
+                if attempt < self.max_attempts:
+                    self._backoff(attempt, archive, last_error, override=wait)
+                    continue
+                raise last_error
+
+            # Any other non-2xx is a malformed query or a protocol change on our
+            # side. Deliberately raised outside the retry path: `raise_for_status`
+            # throws a RequestException, so catching it above would silently retry
+            # our own bugs and turn a fast 404 into three slow ones.
+            response.raise_for_status()
+
+            if attempt > 1:
+                logger.info(f"OAI-PMH recovered for {archive} on attempt {attempt}")
+            return response
+
+        raise last_error if last_error else RuntimeError("unreachable")
+
+    def _backoff(self, attempt: int, archive: str, error: Exception, override: Optional[float] = None) -> None:
+        """Sleep between attempts, clamped to the remaining harvest budget."""
+        wait = override if override is not None else self.backoff_seconds * (2 ** (attempt - 1))
+        wait = max(0.0, min(wait, self._budget_left()))
+        logger.warning(
+            f"OAI-PMH attempt {attempt}/{self.max_attempts} failed for {archive} "
+            f"({type(error).__name__}: {error}); retrying in {wait:.0f}s"
+        )
+        if wait > 0:
+            self._sleep(wait)
+
     def _harvest_archive(self, from_date: str, until_date: str, archive: str) -> List[Dict]:
-        """Harvest all papers from an archive for a date range, handling pagination."""
+        """Harvest all papers from an archive for a date range, handling pagination.
+
+        Pages already fetched are kept when a later page fails; the archive is
+        recorded in `incomplete_archives` so the caller knows the set is partial.
+        """
         papers = []
         resumption_token = None
         page = 0
@@ -114,16 +292,20 @@ class ArxivOAIHarvester:
                 )
 
             try:
-                response = requests.get(url, timeout=60)
-                response.raise_for_status()
-            except requests.exceptions.RequestException as e:
-                logger.error(f"OAI-PMH request failed for {archive}: {e}")
+                response = self._request_with_retry(url, archive)
+            except Exception as e:
+                logger.error(
+                    f"OAI-PMH request failed for {archive} after "
+                    f"{self.max_attempts} attempt(s) on page {page}: {e}"
+                )
+                self.incomplete_archives.append(archive)
                 break
 
             try:
                 root = ET.fromstring(response.content)
             except ET.ParseError as e:
                 logger.error(f"OAI-PMH XML parse error for {archive}: {e}")
+                self.incomplete_archives.append(archive)
                 break
 
             # Check for OAI-PMH errors
@@ -137,6 +319,7 @@ class ArxivOAIHarvester:
                     break
                 else:
                     logger.error(f"OAI-PMH error for {archive}: {error_code} - {error.text}")
+                    self.incomplete_archives.append(archive)
                     break
 
             # Parse records
@@ -149,6 +332,13 @@ class ArxivOAIHarvester:
             # Check for resumption token (pagination)
             token_elem = root.find(f".//{{{OAI_NS}}}resumptionToken")
             if token_elem is not None and token_elem.text:
+                if self._budget_left() <= 0:
+                    logger.error(
+                        f"OAI-PMH deadline reached for {archive} after page {page}; "
+                        f"{len(papers)} papers collected, more were available"
+                    )
+                    self.incomplete_archives.append(archive)
+                    break
                 resumption_token = token_elem.text
                 logger.debug(f"OAI-PMH: Fetching page {page + 1} for {archive}")
             else:

--- a/agents/gatherers/research_gatherer.py
+++ b/agents/gatherers/research_gatherer.py
@@ -115,6 +115,10 @@ class ResearchGatherer(BaseGatherer):
         self.direct_session = requests.Session()
         self.direct_session.trust_env = False
 
+        # Reasons this run's arXiv leg is not trustworthy, collected during
+        # _collect_arxiv and promoted to gatherer-level degradation at the end.
+        self._arxiv_problems: List[str] = []
+
     @property
     def category(self) -> str:
         return 'research'
@@ -133,12 +137,13 @@ class ResearchGatherer(BaseGatherer):
         arXiv publishing schedule:
         - No announcements Friday or Saturday night
         - Saturday/Sunday reports: skip arXiv (no new papers)
-        - Monday: catch-up query for Sat-Mon to catch any anomalies
+        - Monday: RSS for Monday, plus a Sat-Sun sweep to catch any anomalies
 
         Returns:
             Tuple of (mode, from_date) where mode is:
             - 'skip': Saturday/Sunday - don't collect arXiv papers
-            - 'catchup': Monday - 3-day range (Sat through Mon)
+            - 'catchup': Monday - from_date is the Saturday; the sweep runs
+              Sat->Sun on top of RSS, and Sat->Mon only if RSS came back empty
             - 'normal': Tue-Fri - single day query
         """
         from datetime import timedelta
@@ -194,17 +199,20 @@ class ResearchGatherer(BaseGatherer):
     async def _collect_arxiv(self) -> List[CollectedItem]:
         """Collect papers from arXiv using RSS feeds (primary) with OAI-PMH fallback.
 
-        RSS is preferred when available (faster, no pagination). When RSS is empty
-        or unavailable (historical dates), falls back to OAI-PMH which can query
-        any date range by datestamp (announcement date).
+        RSS is preferred whenever it can hold the data (faster, no pagination, and
+        empirically far more reliable: it succeeded on every weekday run in the
+        month before 2026-08-17 and never once needed its fallback). OAI-PMH backs
+        it up and serves historical dates, which RSS cannot.
 
         Weekend handling:
-        - Saturday/Sunday: Skip arXiv collection entirely (no new papers)
-        - Monday: 3-day catchup query (Sat-Mon) to catch any anomalies
+        - Saturday/Sunday report: skip arXiv entirely (no announcements to collect)
+        - Monday report: RSS for Monday's batch, then a best-effort OAI sweep of
+          Sat-Sun for stragglers. That sweep is normally empty -- arXiv makes no
+          Fri/Sat-night announcements -- and must never cost us the RSS papers.
 
         Uses report_date for queries to match RSS behavior:
         - RSS on day X contains papers with datestamp X
-        - OAI-PMH queries datestamp = report_date (or range for Monday)
+        - OAI-PMH queries datestamp = report_date (or a range for Monday/historical)
         """
         # Check weekend/Monday mode first
         mode, from_date = self._get_arxiv_collection_mode()
@@ -215,47 +223,43 @@ class ResearchGatherer(BaseGatherer):
 
         logger.info(f"Collecting from arXiv ({len(self.categories)} categories)")
 
-        loop = asyncio.get_event_loop()
+        self._arxiv_problems: List[str] = []
 
-        # Check if RSS is applicable (only has today's papers)
-        use_rss = self._is_current_collection() and mode != 'catchup'
+        # RSS carries the current day's announcements for every report weekday,
+        # Monday included. Monday used to be excluded here, which made OAI-PMH the
+        # *only* arXiv transport one day a week -- and on 2026-08-17 that endpoint
+        # stalled, both archives timed out, and the day published with zero papers
+        # while RSS was up and serving them in ~1s. RSS is now primary whenever it
+        # can possibly have the data, exactly as Tue-Fri already did.
+        use_rss = self._is_current_collection()
 
         if use_rss:
-            # RSS collection - parallel, no rate limits
-            logger.info("Using RSS feeds (current day collection, no rate limits)...")
-
-            rss_tasks = [
-                loop.run_in_executor(None, self._fetch_category_rss, cat)
-                for cat in self.categories
-            ]
-            rss_results = await asyncio.gather(*rss_tasks, return_exceptions=True)
-
-            # Check total RSS results
-            rss_papers = []
-            rss_errors = 0
-            for cat, rss_result in zip(self.categories, rss_results):
-                if isinstance(rss_result, Exception):
-                    logger.warning(f"RSS failed for {cat}: {rss_result}")
-                    rss_errors += 1
-                elif rss_result:
-                    rss_papers.extend(rss_result)
+            rss_papers = await self._fetch_all_rss()
 
             if rss_papers:
-                # RSS returned papers - use them
                 logger.info(f"Collected {len(rss_papers)} papers via RSS")
                 all_papers = rss_papers
+
+                if mode == 'catchup':
+                    # RSS covered Monday itself; sweep Sat-Sun for stragglers.
+                    # arXiv makes no Fri/Sat-night announcements, so this is
+                    # normally empty -- it exists to catch the anomaly, and must
+                    # never cost us the papers RSS already returned.
+                    all_papers = all_papers + await self._fetch_weekend_tail(from_date)
             else:
-                # RSS empty (all failed) - fall back to OAI-PMH
-                logger.info(f"RSS returned 0 papers, falling back to OAI-PMH for {self.report_date}")
-                all_papers = await self._fetch_via_oai(self.report_date)
-        elif mode == 'catchup':
-            # Monday: 3-day catchup query for Sat-Mon
-            logger.info(f"Monday catchup: fetching arXiv papers from {from_date} to {self.report_date}")
-            all_papers = await self._fetch_via_oai(from_date, self.report_date)
+                # Every RSS category failed or was empty - fall back to OAI-PMH
+                # over the full range for this mode.
+                oai_from = from_date if mode == 'catchup' else self.report_date
+                logger.warning(
+                    f"RSS returned 0 papers, falling back to OAI-PMH for "
+                    f"{oai_from} to {self.report_date}"
+                )
+                all_papers = await self._fetch_via_oai(oai_from, self.report_date)
         else:
-            # Historical collection - use OAI-PMH directly (RSS doesn't have past data)
+            # Historical collection - RSS only ever holds today's announcements
+            oai_from = from_date if mode == 'catchup' else self.report_date
             logger.info(f"Using OAI-PMH (historical collection for {self.report_date})")
-            all_papers = await self._fetch_via_oai(self.report_date)
+            all_papers = await self._fetch_via_oai(oai_from, self.report_date)
 
         # Deduplicate by arXiv ID
         seen_arxiv_ids = set()
@@ -268,14 +272,92 @@ class ResearchGatherer(BaseGatherer):
                 unique_papers.append(paper)
 
         logger.info(f"Collected {len(unique_papers)} unique papers from arXiv")
+
+        # arXiv going quiet on a day it should have papers is the failure mode that
+        # published green on 2026-08-17. Say so, so the orchestrator can mark the
+        # source degraded instead of reporting success with an empty shelf.
+        if not unique_papers:
+            self._arxiv_problems.append(
+                f"arXiv returned 0 papers on a {mode} day ({self.report_date}); "
+                "this weekday normally has papers"
+            )
+        for problem in self._arxiv_problems:
+            self.note_degradation(problem)
+
         return unique_papers
 
-    async def _fetch_via_oai(self, from_date: str, until_date: Optional[str] = None) -> List[CollectedItem]:
+    async def _fetch_all_rss(self) -> List[CollectedItem]:
+        """Fetch every configured arXiv category over RSS, in parallel.
+
+        Per-category failures are tolerated: RSS is a fan-out over independent
+        feeds and one bad category should not discard the other six.
+        """
+        logger.info("Using RSS feeds (current day collection, no rate limits)...")
+        loop = asyncio.get_event_loop()
+
+        rss_results = await asyncio.gather(
+            *[
+                loop.run_in_executor(None, self._fetch_category_rss, cat)
+                for cat in self.categories
+            ],
+            return_exceptions=True,
+        )
+
+        rss_papers: List[CollectedItem] = []
+        failed = []
+        for cat, rss_result in zip(self.categories, rss_results):
+            if isinstance(rss_result, Exception):
+                logger.warning(f"RSS failed for {cat}: {rss_result}")
+                failed.append(cat)
+            elif rss_result:
+                rss_papers.extend(rss_result)
+
+        if failed and rss_papers:
+            # Partial RSS still publishes, but not silently.
+            self._arxiv_problems.append(
+                f"arXiv RSS failed for {len(failed)}/{len(self.categories)} "
+                f"categories ({', '.join(failed)})"
+            )
+
+        return rss_papers
+
+    async def _fetch_weekend_tail(self, from_date: str) -> List[CollectedItem]:
+        """Sweep Sat-Sun for announcements RSS could not have carried.
+
+        Best-effort by construction: RSS has already supplied Monday's papers, so
+        a failure here is worth a log line and nothing more. Never raises.
+        """
+        from datetime import timedelta
+
+        report_dt = datetime.strptime(self.report_date, '%Y-%m-%d')
+        tail_until = (report_dt - timedelta(days=1)).strftime('%Y-%m-%d')
+
+        logger.info(f"Monday catchup: sweeping arXiv {from_date} to {tail_until} for weekend stragglers")
+        try:
+            tail = await self._fetch_via_oai(from_date, tail_until, best_effort=True)
+        except Exception as e:
+            logger.warning(f"Weekend catchup sweep failed ({type(e).__name__}: {e}); "
+                           "keeping the papers RSS already returned")
+            return []
+
+        if tail:
+            logger.info(f"Weekend catchup sweep found {len(tail)} extra papers")
+        return tail
+
+    async def _fetch_via_oai(
+        self,
+        from_date: str,
+        until_date: Optional[str] = None,
+        best_effort: bool = False,
+    ) -> List[CollectedItem]:
         """Fetch papers via OAI-PMH for a date or date range.
 
         Args:
             from_date: Start date in YYYY-MM-DD format
             until_date: End date in YYYY-MM-DD format. If None, uses from_date (single day).
+            best_effort: When True this is a supplementary sweep whose failure does
+                not degrade the day (RSS already supplied the primary set), so an
+                incomplete harvest is logged but not recorded as a problem.
 
         Returns:
             List of CollectedItem for new papers announced in the date range
@@ -288,6 +370,20 @@ class ResearchGatherer(BaseGatherer):
 
         date_desc = from_date if not until_date or from_date == until_date else f"{from_date} to {until_date}"
         logger.info(f"OAI-PMH returned {len(papers)} new papers for {date_desc}")
+
+        # An incomplete harvest returns a floor, not an answer. On the primary
+        # path that has to reach collection_status; on a best-effort sweep it does
+        # not, because the day's real data came from RSS.
+        if not harvester.last_harvest_complete:
+            detail = (
+                f"arXiv OAI-PMH harvest incomplete for {date_desc} "
+                f"(gave up on: {', '.join(harvester.incomplete_archives)})"
+            )
+            if best_effort:
+                logger.warning(f"{detail}; ignoring, RSS supplied the primary set")
+            else:
+                logger.error(detail)
+                self._arxiv_problems.append(detail)
 
         # Convert to CollectedItem format
         items = []

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -307,8 +307,11 @@ class MainOrchestrator:
                 logger.info("Phase 1: Gathering from all sources...")
                 gathered_items, collection_status = await self._gather_all()
                 total_items = sum(len(items) for items in gathered_items.values())
-                has_failures = any(s.get('status') == 'failed' for s in collection_status.values())
-                status = 'partial' if has_failures else 'success'
+                degraded = any(
+                    s.get('status') in ('failed', 'partial')
+                    for s in collection_status.values()
+                )
+                status = 'partial' if degraded else 'success'
                 phases.end_phase(status, details=f"{total_items} items")
                 self._save_checkpoint('gathering', {
                     'collection_status': collection_status,
@@ -767,7 +770,7 @@ class MainOrchestrator:
             if error:
                 collection_status[name] = {'status': 'failed', 'count': 0, 'error': error}
             else:
-                collection_status[name] = {'status': 'success', 'count': len(items), 'error': None}
+                collection_status[name] = self._status_for(name, items)
 
         # Capture social sub-platform status from SocialGatherer
         social_gatherer = self.gatherers.get('social')
@@ -785,7 +788,7 @@ class MainOrchestrator:
             news_items = await news_gatherer.gather(social_posts=social_posts)
             logger.info(f"    news gatherer collected {len(news_items)} items")
             results['news'] = news_items
-            collection_status['news'] = {'status': 'success', 'count': len(news_items), 'error': None}
+            collection_status['news'] = self._status_for('news', news_items)
         except Exception as e:
             logger.error(f"    news gatherer failed: {e}")
             results['news'] = []
@@ -794,6 +797,24 @@ class MainOrchestrator:
         self._attach_source_timing(collection_status)
 
         return results, collection_status
+
+    def _status_for(self, name: str, items: list) -> Dict[str, Any]:
+        """Build one source's status row, honouring self-reported degradation.
+
+        A gatherer that returns normally is only 'success' if it also has nothing
+        to confess. Before this, status was binary on whether gather() raised, so
+        a source that caught its own transport errors and returned a short list
+        reported clean -- which is how three weeks of missing arXiv, and again
+        2026-08-17, published as green runs.
+        """
+        gatherer = self.gatherers.get(name)
+        degradation = gatherer.get_degradation() if hasattr(gatherer, 'get_degradation') else None
+
+        if degradation:
+            logger.warning(f"    {name} gatherer degraded: {degradation}")
+            return {'status': 'partial', 'count': len(items), 'error': degradation}
+
+        return {'status': 'success', 'count': len(items), 'error': None}
 
     def _attach_source_timing(self, collection_status: Dict[str, Dict[str, Any]]) -> None:
         """Fold each gatherer's per-source spans into the status dict.

--- a/tests/arxiv_oai_resilience_test.py
+++ b/tests/arxiv_oai_resilience_test.py
@@ -1,0 +1,361 @@
+"""Guards for the arXiv OAI-PMH harvester's failure behaviour.
+
+Written after the 2026-08-17 outage, in which the Monday catch-up harvest was
+the *only* arXiv transport that day, both archives hit a 60s read timeout on
+the first and only attempt, `_harvest_archive` swallowed the exception and
+returned `[]`, and the run published `research: success` with 12 items against
+a Monday median of 334.
+
+Three separate defects made that possible, and each has a test here:
+  1. no retry            -> one stall was fatal
+  2. 60s timeout         -> a *successful* call measured 51.5s that morning
+  3. empty == failed     -> zero papers from a dead socket looked like a quiet day
+
+Runs in the dependency-light guard job: `requests` is stubbed, so the whole
+transport is under test control and nothing touches the network.
+
+  python3 -m unittest tests.arxiv_oai_resilience_test -v
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# --------------------------------------------------------------------------
+# Stub `requests` before loading the harvester. Real exception classes, so the
+# module's `except requests.exceptions.RequestException` clauses behave.
+# --------------------------------------------------------------------------
+class _RequestException(Exception):
+    pass
+
+
+class _HTTPError(_RequestException):
+    pass
+
+
+class _ReadTimeout(_RequestException):
+    pass
+
+
+if "requests" not in sys.modules:
+    _exceptions = types.ModuleType("requests.exceptions")
+    _exceptions.RequestException = _RequestException
+    _exceptions.HTTPError = _HTTPError
+    _exceptions.ReadTimeout = _ReadTimeout
+
+    _requests = types.ModuleType("requests")
+    _requests.exceptions = _exceptions
+    _requests.get = None  # every test installs its own
+
+    sys.modules["requests"] = _requests
+    sys.modules["requests.exceptions"] = _exceptions
+
+requests = sys.modules["requests"]
+
+_spec = importlib.util.spec_from_file_location(
+    "_arxiv_oai", REPO_ROOT / "agents" / "gatherers" / "arxiv_oai.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+ArxivOAIHarvester = _mod.ArxivOAIHarvester
+
+OAI_NS = "http://www.openarchives.org/OAI/2.0/"
+RAW_NS = "http://arxiv.org/OAI/arXivRaw/"
+
+
+def _page(ids, datestamp="2026-08-17", resumption_token=None):
+    """Build one valid ListRecords page containing v1 records for `ids`."""
+    records = "".join(
+        f"""
+        <record>
+          <header><identifier>oai:arXiv.org:{i}</identifier>
+            <datestamp>{datestamp}</datestamp></header>
+          <metadata>
+            <arXivRaw xmlns="{RAW_NS}">
+              <id>{i}</id>
+              <title>Paper {i}</title>
+              <authors>A. Author</authors>
+              <abstract>An abstract.</abstract>
+              <categories>cs.AI cs.LG</categories>
+              <version version="v1"><date>Mon, 17 Aug 2026 00:00:00 GMT</date></version>
+            </arXivRaw>
+          </metadata>
+        </record>"""
+        for i in ids
+    )
+    token = (
+        f"<resumptionToken>{resumption_token}</resumptionToken>"
+        if resumption_token
+        else "<resumptionToken/>"
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="{OAI_NS}">
+  <ListRecords>{records}{token}</ListRecords>
+</OAI-PMH>""".encode()
+
+
+class _Resp:
+    def __init__(self, content=b"", status_code=200, headers=None):
+        self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise _HTTPError(f"HTTP {self.status_code}")
+
+
+class _Transport:
+    """Scripted responses; each entry is a _Resp or an exception to raise."""
+
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.timeouts = []
+
+    def __call__(self, url, timeout=None, **kwargs):
+        self.calls.append(url)
+        self.timeouts.append(timeout)
+        item = self.responses.pop(0) if self.responses else _Resp(_page([]))
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _Clock:
+    """Monotonic clock that only advances when the code sleeps."""
+
+    def __init__(self):
+        self.t = 0.0
+        self.slept = []
+
+    def now(self):
+        return self.t
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.t += seconds
+
+
+def _harvester(transport, clock=None, **kw):
+    clock = clock or _Clock()
+    requests.get = transport
+    kw.setdefault("backoff_seconds", 5.0)
+    kw.setdefault("timeout", 180.0)
+    kw.setdefault("deadline_seconds", 600.0)
+    return ArxivOAIHarvester(
+        ["cs.AI", "cs.LG"], sleep=clock.sleep, now=clock.now, **kw
+    ), clock
+
+
+class RetryBehaviour(unittest.TestCase):
+    def test_transient_timeout_is_retried_and_recovers(self):
+        """The 08-17 failure was a single stall. One retry would have saved it."""
+        transport = _Transport(_ReadTimeout("read timed out"), _Resp(_page(["2608.001"])))
+        harvester, clock = _harvester(transport, max_attempts=3)
+
+        papers = harvester.harvest_date("2026-08-17")
+
+        self.assertEqual(1, len(papers))
+        self.assertEqual(2, len(transport.calls), "should have retried once")
+        self.assertTrue(harvester.last_harvest_complete)
+        self.assertEqual([], harvester.incomplete_archives)
+        self.assertEqual([5.0], clock.slept, "first backoff is the base delay")
+
+    def test_backoff_grows_exponentially(self):
+        transport = _Transport(
+            _ReadTimeout("1"), _ReadTimeout("2"), _Resp(_page(["2608.002"]))
+        )
+        harvester, clock = _harvester(transport, max_attempts=3)
+
+        harvester.harvest_date("2026-08-17")
+
+        self.assertEqual([5.0, 10.0], clock.slept)
+
+    def test_exhausted_retries_mark_the_archive_incomplete(self):
+        """Zero papers from a dead socket must not look like a quiet day."""
+        transport = _Transport(*[_ReadTimeout("stalled")] * 9)
+        harvester, _ = _harvester(transport, max_attempts=3)
+
+        papers = harvester.harvest_date("2026-08-17")
+
+        self.assertEqual([], papers)
+        self.assertFalse(harvester.last_harvest_complete)
+        # Both archives derived from cs.AI/cs.LG collapse to 'cs'
+        self.assertEqual(["cs"], harvester.incomplete_archives)
+
+    def test_harvest_date_never_raises_on_transport_failure(self):
+        """A dead endpoint degrades the day; it must not kill the pipeline."""
+        transport = _Transport(*[_ReadTimeout("stalled")] * 9)
+        harvester, _ = _harvester(transport, max_attempts=3)
+
+        try:
+            harvester.harvest_date("2026-08-17")
+        except Exception as exc:  # noqa: BLE001 - that's the point of the test
+            self.fail(f"harvest_date raised {type(exc).__name__}: {exc}")
+
+    def test_empty_day_is_complete_not_incomplete(self):
+        """A genuinely empty range is a fact, not a fault."""
+        transport = _Transport(_Resp(_page([])))
+        harvester, _ = _harvester(transport)
+
+        papers = harvester.harvest_date("2026-08-15", "2026-08-16")
+
+        self.assertEqual([], papers)
+        self.assertTrue(harvester.last_harvest_complete)
+
+
+class RateLimitBehaviour(unittest.TestCase):
+    def test_503_is_retried_honouring_retry_after(self):
+        transport = _Transport(
+            _Resp(b"", status_code=503, headers={"Retry-After": "12"}),
+            _Resp(_page(["2608.003"])),
+        )
+        harvester, clock = _harvester(transport, max_attempts=3)
+
+        papers = harvester.harvest_date("2026-08-17")
+
+        self.assertEqual(1, len(papers))
+        self.assertEqual([12.0], clock.slept, "must honour Retry-After, not our backoff")
+        self.assertTrue(harvester.last_harvest_complete)
+
+    def test_unparseable_retry_after_falls_back_to_our_backoff(self):
+        transport = _Transport(
+            _Resp(b"", status_code=503, headers={"Retry-After": "Wed, 19 Aug 2026 07:00:00 GMT"}),
+            _Resp(_page(["2608.004"])),
+        )
+        harvester, clock = _harvester(transport, max_attempts=3)
+
+        harvester.harvest_date("2026-08-17")
+
+        self.assertEqual([5.0], clock.slept)
+
+    def test_404_is_not_retried(self):
+        """Client errors are our bug, not the network's; retrying just wastes time."""
+        transport = _Transport(_Resp(b"", status_code=404))
+        harvester, _ = _harvester(transport, max_attempts=3)
+
+        harvester.harvest_date("2026-08-17")
+
+        self.assertEqual(1, len(transport.calls))
+        self.assertFalse(harvester.last_harvest_complete)
+
+
+class PaginationBehaviour(unittest.TestCase):
+    def test_pages_already_fetched_survive_a_later_failure(self):
+        """Partial beats nothing -- but it must still be flagged as partial."""
+        transport = _Transport(
+            _Resp(_page(["2608.010", "2608.011"], resumption_token="tok1")),
+            *[_ReadTimeout("died on page 2")] * 3,
+        )
+        harvester, _ = _harvester(transport, max_attempts=3)
+
+        papers = harvester.harvest_date("2026-08-17")
+
+        self.assertEqual(2, len(papers), "page 1 results must be kept")
+        self.assertFalse(harvester.last_harvest_complete)
+
+    def test_full_pagination_completes(self):
+        transport = _Transport(
+            _Resp(_page(["2608.020"], resumption_token="tok1")),
+            _Resp(_page(["2608.021"])),
+        )
+        harvester, _ = _harvester(transport)
+
+        papers = harvester.harvest_date("2026-08-17")
+
+        self.assertEqual(2, len(papers))
+        self.assertTrue(harvester.last_harvest_complete)
+
+
+class DeadlineBehaviour(unittest.TestCase):
+    def test_deadline_stops_the_retry_loop(self):
+        """timeout x attempts x pages x archives must not run unbounded."""
+        transport = _Transport(*[_ReadTimeout("stalled")] * 50)
+        harvester, clock = _harvester(
+            transport, max_attempts=10, backoff_seconds=30.0, deadline_seconds=60.0
+        )
+
+        harvester.harvest_date("2026-08-17")
+
+        self.assertLessEqual(sum(clock.slept), 60.0)
+        self.assertFalse(harvester.last_harvest_complete)
+
+    def test_request_timeout_is_clamped_to_remaining_budget(self):
+        transport = _Transport(_Resp(_page([])))
+        harvester, _ = _harvester(transport, timeout=180.0, deadline_seconds=30.0)
+
+        harvester.harvest_date("2026-08-17")
+
+        self.assertEqual([30.0], transport.timeouts)
+
+
+class ConfiguredDefaults(unittest.TestCase):
+    def test_default_timeout_clears_the_measured_slow_call(self):
+        """60s was the old value. A *successful* call took 51.5s on 2026-08-17."""
+        self.assertGreaterEqual(
+            _mod.DEFAULT_TIMEOUT, 120.0,
+            "default OAI timeout must leave headroom above the observed 51.5s success",
+        )
+
+    def test_retries_are_on_by_default(self):
+        self.assertGreaterEqual(_mod.DEFAULT_MAX_ATTEMPTS, 2)
+
+    def test_deadline_is_bounded(self):
+        self.assertGreater(_mod.DEFAULT_DEADLINE, 0)
+        self.assertLessEqual(
+            _mod.DEFAULT_DEADLINE, 1800.0,
+            "an unbounded harvest can eat the whole job budget",
+        )
+
+
+class MondayUsesRss(unittest.TestCase):
+    """Source-level guard on the fix that actually prevents the outage.
+
+    A behavioural test would need the full gatherer (feedparser, the agents
+    package, network fakes for seven RSS categories). The regression is a single
+    boolean, so it is pinned directly: `use_rss` must not be gated on the
+    collection mode. Restoring `and mode != 'catchup'` puts Monday back on an
+    OAI-only path with no fallback.
+    """
+
+    def _assign_source(self, name):
+        src = (REPO_ROOT / "agents" / "gatherers" / "research_gatherer.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == name:
+                        return ast.get_source_segment(src, node.value)
+        self.fail(f"no assignment to `{name}` found in research_gatherer.py")
+
+    def test_use_rss_is_not_gated_on_catchup_mode(self):
+        expr = self._assign_source("use_rss")
+        self.assertNotIn(
+            "mode", expr,
+            "use_rss must not depend on the collection mode: gating it on "
+            "`mode != 'catchup'` made OAI-PMH the sole Monday transport, which "
+            "is exactly how 2026-08-17 published zero arXiv papers",
+        )
+        self.assertIn("_is_current_collection", expr)
+
+    def test_weekend_tail_is_best_effort(self):
+        src = (REPO_ROOT / "agents" / "gatherers" / "research_gatherer.py").read_text()
+        self.assertIn(
+            "best_effort=True", src,
+            "the Sat-Sun sweep must not be able to discard the papers RSS returned",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What happened

The 2026-08-17 Monday report published **12 research items against a same-weekday median of 334** (4% of normal), while `collection_status` reported `research: success`.

Three defects stacked:

1. **Monday was the only weekday that did not use RSS.** `use_rss` was gated on `mode != 'catchup'`, making `oaipmh.arxiv.org` the *sole* arXiv transport once a week. It was therefore exercised ~1 day in 7, so a regression in it stays invisible for ~6 days at a time.
2. **No retry, and a 60s timeout.** A *successful* `ListRecords` for the `cs` archive measured **51.5s** that morning. The identical query returned in 0.6s, 51.5s, and >90s within minutes — the endpoint stalls intermittently rather than being uniformly slow. Both archives timed out on their first and only attempt.
3. **Failure was indistinguishable from an empty day.** `_harvest_archive` caught the timeout, logged, `break`-ed, returned `[]`, and the gatherer reported success.

RSS was healthy the whole time, serving Monday's announcements in ~1s.

## Evidence

| Attempt | `cs` archive | `stat` archive |
|---|---|---|
| CI 03:22 ET | timeout @60s | timeout @60s |
| local ~10:55 | 51.5s OK | >90s fail |
| local ~11:00 | 0.6s OK | — |

Prior Monday harvests: 9.44s (Jul 27), 8.06s (Aug 3), 7.08s (Aug 10) — no degradation trend, a step change to total failure. RSS succeeded on all 12 non-Monday weekdays in the window and never once needed its fallback.

A Sat-to-Mon OAI query returns **842 `cs` records, all datestamped Monday** — arXiv makes no Fri/Sat-night announcements, so the old 3-day "catch-up" window only ever contained Monday's batch. RSS carries the same set.

## Changes

- **RSS is primary on every report weekday, Monday included.** Monday adds a best-effort Sat-Sun OAI sweep for stragglers that can never discard the papers RSS returned.
- **OAI-PMH retries** transient failures (3 attempts, exponential backoff, honours `Retry-After` on 429/5xx). Non-retryable 4xx raise immediately rather than burning three slow attempts on our own bug.
- **Timeout 60s to 180s**, plus a 600s whole-harvest deadline so `timeout x attempts x pages x archives` stays bounded. All four knobs env-overridable and documented.
- **Partial harvests are kept but flagged** via `incomplete_archives`, so zero papers from a dead socket no longer reads as a quiet day.
- **`BaseGatherer.note_degradation()`**; the orchestrator reports `partial` instead of `success` when a gatherer admits incompleteness. Flows through the existing `json_generator` logic to `collection_status.overall` and a site-visible warning.
- **Anomaly finding surfaced natively.** The checker detected this correctly and POSTed — delivery returned **HTTP 403**, so it reached nobody. Findings now also emit a GitHub `::error::` annotation and job-summary entry, and a failed delivery is itself an error annotation.

## Tests

`tests/arxiv_oai_resilience_test.py` — 17 cases, stdlib-only (`requests` stubbed, no network), wired into the dependency-light guard job. Covers retry/recovery, backoff growth, `Retry-After`, 4xx not retried, partial-page preservation, deadline bounding, and a source-level guard that `use_rss` never regains a `mode` dependency.

Full dependency-light guard suite passes locally (11/11 modules).

## Follow-up not in this PR

`PIPELINE_ALERT_TOKEN` / `PIPELINE_ALERT_URL` — the 403 is a live credential problem this PR does not fix. Today was the first time the alert path had ever fired, so it may have been broken since setup.