### PR TITLE
feat(cost): price Gemini 3.8 Flash on OpenRouter

### DIFF
--- a/agents/cost_tracker.py
+++ b/agents/cost_tracker.py
@@ -227,6 +227,16 @@ class CostTracker:
             self.output_price = 4.25
             self.cache_write_price = 1.25
             self.cache_hit_price = 0.15
+        elif "gemini-3.8-flash" in model.lower():
+            # google/gemini-3.8-flash -- OpenRouter's standard on-demand tier.
+            # Verified live against the OpenRouter model record on 2026-09-03:
+            # $0.75/MTok prompt, $3.75/MTok completion, $0.075/MTok cache read.
+            # No cache-write premium is published, so writes bill at the prompt
+            # rate. Reasoning tokens are billed as completion tokens.
+            self.input_price = 0.75
+            self.output_price = 3.75
+            self.cache_write_price = 0.75
+            self.cache_hit_price = 0.075
         elif "glm-5.3-flash" in model.lower():
             # z-ai/GLM-5.3-Flash -- ox-alpha's real identity after the reveal.
             # Verified live against /api/v1/models/z-ai/glm-5.3-flash/endpoints


### PR DESCRIPTION
## Summary
- price `google/gemini-3.8-flash` at OpenRouter's published on-demand rates
- use $0.75/M input, $3.75/M output, and $0.075/M cache-read
- bill cache writes at the prompt rate and stop marking Gemini cost as an Opus estimate

## Validation
- `git diff --check`
- focused pricing regression suite passed locally (16 tests)

Pricing source: https://openrouter.ai/google/gemini-3.8-flash