### PR TITLE
Add AI Weekly RSS feed

### DIFF
--- a/config/rss_feeds.txt
+++ b/config/rss_feeds.txt
@@ -38,6 +38,7 @@ https://huggingface.co/blog/feed.xml
 # all 404 (verified 2026-04-17). Removed to silence warnings.
 # https://blog.langchain.dev/rss/
 https://every.to/chain-of-thought/feed
+https://aiweekly.co/feed
 https://lastweekin.ai/feed
 https://www.latent.space/feed
 https://semianalysis.com/feed/


### PR DESCRIPTION
## Summary

Add AI Weekly's public RSS feed to the AI-news source list. The publication tracks what AI experts are reading and sharing across models, agents, funding, policy, and research, with three editions per week.

## Verification

- Fetched `https://aiweekly.co/feed` successfully as RSS 2.0.
- Kept the one-feed-per-line configuration format.
- Per repository guidance, I did not run the pipeline or tests; `git diff --check` passes.

## Disclosure

I am the founder of AI Weekly. I used an AI assistant to help prepare this narrowly scoped contribution and reviewed the submitted wording and diff.
